### PR TITLE
[PR 8] Added Media Type Breakdown Analysis

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -5,7 +5,10 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
 from datetime import datetime
 from app.models import db, MediaEntry, Book, Movie, TVShow, Music
+from app.utils import get_media_type_breakdown, get_user_media_identity
 main = Blueprint('main', __name__)
+
+
 
 @main.route('/')
 def welcome():
@@ -439,4 +442,11 @@ def delete_account():
 
 @main.route('/foryou')
 def for_you():
-    return render_template('foryou.html')
+    user_id = session.get('user_id')
+    if not user_id:
+        flash("Please log in to access your dashboard.", "error")
+        return redirect(url_for('main.login'))
+
+    media_counts = get_media_type_breakdown(user_id)
+    identity_label = get_user_media_identity(media_counts)
+    return render_template("foryou.html", identity=identity_label, breakdown=media_counts)

--- a/app/templates/foryou.html
+++ b/app/templates/foryou.html
@@ -1,45 +1,20 @@
-{% extends "base.html" %} {% block title %}For You – Soul Maps{% endblock %} {%
-block content %}
-<div class="home-container">
-  <h2>For You</h2>
+{% extends "base.html" %}
+{% block title %} For You – Soul Maps{% endblock %}
 
-  <div class="content">
-    <div class="recommended-section">
-      <h3>Recommended Media Maps</h3>
-      <ul>
-        <li><b>Dark Matter</b> — trending sci-fi show map</li>
-        <li><b>Mistborn</b> — epic fantasy book journey</li>
-        <li>
-          <b>Everything Everywhere All At Once</b> — multiverse madness movie
-          map
-        </li>
-      </ul>
-    </div>
+{% block content %}
+<div class="container py-4">
+  <div class="card p-4 shadow-sm text-center">
+    <h2 class="mb-3">{{ identity }}</h2>
+    <p class="lead">Here's a summary of your media journey:</p>
 
-    <div class="brain-image">
-      <img
-        src="{{ url_for('static', filename='media/brainNetwork.png') }}"
-        alt="Brain Network"
-      />
-    </div>
-
-    <div class="trending-section">
-      <h3>Trending in Your Network</h3>
-      <ul>
-        <li><b>Bob</b> recommends <i>The Three-Body Problem</i></li>
-        <li><b>Alice</b> is loving <i>Severance</i></li>
-        <li><b>Charlie</b> just finished <i>The Sandman</i></li>
-      </ul>
-    </div>
-
-    <div class="discover-section">
-      <h3>Discover New Maps</h3>
-      <ul>
-        <li><i>Arcane</i> — animation lovers’ favorite</li>
-        <li><i>Dune</i> — spice must flow 🌌</li>
-        <li><i>Project Hail Mary</i> — science survival story</li>
-      </ul>
-    </div>
+    <ul class="list-group list-group-flush mt-4">
+      {% for type, count in breakdown.items() %}
+      <li class="list-group-item d-flex justify-content-between">
+        <span class="text-capitalize">{{ type.replace('_', ' ') }}</span>
+        <span>{{ count }}</span>
+      </li>
+      {% endfor %}
+    </ul>
   </div>
 </div>
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,23 @@
+from app.models import MediaEntry
+from app import db
+from sqlalchemy import func
+
+def get_media_type_breakdown(user_id):
+    counts = (
+        db.session.query(MediaEntry.media_type, func.count(MediaEntry.id))
+        .filter_by(user_id=user_id)
+        .group_by(MediaEntry.media_type)
+        .all()
+    )
+    return {media_type: count for media_type, count in counts}
+def get_user_media_identity(counts_dict):
+    if not counts_dict:
+        return "You are a Media Explorer"
+
+    top_type = max(counts_dict, key=counts_dict.get)
+    return {
+        'book': "You are a Reader",
+        'movie': "You are a Cinephile",
+        'music': "You are a Music Lover",
+        'tv_show': "You are a Binge-Watcher"
+    }.get(top_type, "You are a Media Explorer")


### PR DESCRIPTION
This PR adds backend logic and a new route for the /foryou dashboard, providing users with a personalized media identity label and a breakdown of how many books, movies, music, and shows they’ve logged.

- Created utility functions to:
    - Count media entries by type for the current user - 
    - Determine identity label based on most-consumed media
- Edited /foryou route and foryou.html template

<img width="1338" alt="Screenshot 2025-05-12 at 8 34 02 am" src="https://github.com/user-attachments/assets/93b9d81b-8053-4f10-b3f6-8ac3a330e15a" />
